### PR TITLE
Add language and web search options

### DIFF
--- a/project_root/app.py
+++ b/project_root/app.py
@@ -1,0 +1,47 @@
+import streamlit as st
+from pathlib import Path
+
+from graph_build import exec_graph
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+DATA_DIR.mkdir(exist_ok=True)
+
+st.set_page_config(page_title="논문 요약·Q&A", layout="wide")
+
+st.title("시민 친화형 논문 요약 + Q&A 챗봇")
+
+uploaded = st.file_uploader("논문 PDF 업로드", type=["pdf"])
+ext_flag = st.checkbox("외부 웹 정보도 포함")
+lang_option = st.radio("언어", ["한국어", "영어", "한국어+영어"], index=0)
+sum_style = st.selectbox("요약 형식", ["TL;DR", "섹션별", "Deep-Dive"])
+
+if uploaded:
+    pdf_path = DATA_DIR / uploaded.name
+    with open(pdf_path, "wb") as f:
+        f.write(uploaded.getbuffer())
+
+    if st.button("요약 생성"):
+        result = exec_graph(
+            pdf_path=str(pdf_path),
+            summary_type=sum_style.lower(),
+            ext_flag=ext_flag,
+            lang_option=lang_option,
+        )
+        st.markdown(result.get("summary_ko", "요약 실패"))
+        if "영어" in lang_option:
+            st.markdown("---")
+            st.markdown(result.get("summary_en", "English summary failed"))
+
+    st.header("질문하기")
+    user_q = st.text_input("질문")
+    if st.button("Ask") and user_q:
+        ans_state = exec_graph(
+            pdf_path=str(pdf_path),
+            user_query=user_q,
+            ext_flag=ext_flag,
+            lang_option=lang_option,
+        )
+        st.markdown(ans_state.get("answer_ko", "답변 실패"))
+        if "영어" in lang_option:
+            st.markdown("---")
+            st.markdown(ans_state.get("answer_en", "English answer failed"))

--- a/project_root/graph_build.py
+++ b/project_root/graph_build.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, TypedDict
+
+from langchain.schema import Document
+from langgraph.graph import StateGraph
+
+from nodes.load_pdf import load
+from nodes.split import split
+from nodes.embed_store import embed
+from nodes.summarize import summarize
+from nodes.keyword_highlight import highlight
+from nodes.web_search import web_search
+from nodes.retrieve_answer import retrieve, answer
+from nodes.error_handler import handle
+
+
+class PaperState(TypedDict, total=False):
+    pdf_path: str
+    metadata: Dict[str, Any]
+    chunks_raw: List[Document]
+    chunks: List[Document]
+    vector: Any
+    summary_type: str
+    lang_option: str
+    ext_flag: bool
+    summary_ko: str
+    summary_en: str
+    user_query: str
+    answer_ko: str
+    answer_en: str
+    external_refs: List[Dict[str, str]]
+    keywords: List[str]
+    retrieved_docs: List[Document]
+    error: str
+
+
+def route(state: Dict[str, Any]) -> str:
+    """Decide next step based on state."""
+    if state.get("error"):
+        return "error"
+    if state.get("user_query"):
+        return "question"
+    return "summary"
+
+
+def build_graph() -> StateGraph:
+    """Construct the processing StateGraph."""
+    graph = StateGraph(PaperState)
+
+    graph.add_node("LoadPDF", load)
+    graph.add_node("Split", split)
+    graph.add_node("EmbedStore", embed)
+    graph.add_node("DecisionRouter", lambda x: x)
+    graph.add_node("Summarize", summarize)
+    graph.add_node("Highlight", highlight)
+    graph.add_node("WebSearch", web_search)
+    graph.add_node("Retrieve", retrieve)
+    graph.add_node("Answer", answer)
+    graph.add_node("ErrorHandler", handle)
+
+    graph.set_entry_point("LoadPDF")
+    graph.add_edge("LoadPDF", "Split")
+    graph.add_edge("Split", "EmbedStore")
+    graph.add_edge("EmbedStore", "DecisionRouter")
+
+    graph.add_conditional_edges(
+        "DecisionRouter",
+        route,
+        {
+            "summary": "Summarize",
+            "question": "Retrieve",
+            "error": "ErrorHandler",
+        },
+    )
+
+    graph.add_edge("Summarize", "Highlight")
+    graph.add_edge("Highlight", "WebSearch")
+    graph.add_edge("WebSearch", "ErrorHandler")
+
+    graph.add_edge("Retrieve", "Answer")
+    graph.add_edge("Answer", "ErrorHandler")
+
+    graph.set_finish_point("ErrorHandler")
+
+    return graph
+
+
+def exec_graph(**kwargs: Any) -> PaperState:
+    """Run the compiled graph with provided keyword state."""
+    graph = build_graph().compile()
+    state: PaperState = {}
+    state.update(kwargs)
+    return graph.invoke(state)

--- a/project_root/nodes/embed_store.py
+++ b/project_root/nodes/embed_store.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from typing import Dict, Any
+
+from langchain.vectorstores import Chroma
+from langchain_community.embeddings import OpenAIEmbeddings
+
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+DATA_DIR.mkdir(exist_ok=True)
+
+
+def embed(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Embed chunks and store in a Chroma vector DB."""
+    docs = state.get("chunks")
+    if not docs:
+        state["error"] = "No chunks to embed"
+        return state
+
+    embedding = OpenAIEmbeddings()
+    try:
+        vectordb = Chroma.from_documents(documents=docs, embedding=embedding, persist_directory=str(DATA_DIR))
+        vectordb.persist()
+        state["vector"] = vectordb
+    except Exception as exc:
+        state["error"] = str(exc)
+    return state

--- a/project_root/nodes/error_handler.py
+++ b/project_root/nodes/error_handler.py
@@ -1,0 +1,9 @@
+from typing import Dict, Any
+
+
+def handle(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Simple error handler that logs the error message."""
+    error = state.get("error")
+    if error:
+        print(f"[ErrorHandler] {error}")
+    return state

--- a/project_root/nodes/keyword_highlight.py
+++ b/project_root/nodes/keyword_highlight.py
@@ -1,0 +1,26 @@
+from typing import Dict, Any
+
+from keybert import KeyBERT
+import spacy
+
+
+_nlp = spacy.load("en_core_web_sm")
+_kw_model = KeyBERT()
+
+
+def highlight(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract keywords and highlight them in the summary."""
+    summary = state.get("summary_ko")
+    if not summary:
+        state["error"] = "No summary available to highlight"
+        return state
+
+    try:
+        keywords = [kw for kw, _ in _kw_model.extract_keywords(summary, top_n=5, use_mmr=True)]
+        for kw in keywords:
+            summary = summary.replace(kw, f"**{kw}**")
+        state["summary_ko"] = summary
+        state["keywords"] = keywords
+    except Exception as exc:
+        state["error"] = str(exc)
+    return state

--- a/project_root/nodes/load_pdf.py
+++ b/project_root/nodes/load_pdf.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from typing import Dict, Any
+
+from langchain_community.document_loaders import PyPDFLoader
+
+
+def load(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Load a PDF file and store raw documents in state.
+
+    Expects ``state['pdf_path']`` to contain a path to the PDF file.
+    Stores the loaded ``Document`` list in ``state['chunks_raw']``.
+    """
+    pdf_path = Path(state.get("pdf_path", ""))
+    if not pdf_path.is_file():
+        state["error"] = f"PDF not found: {pdf_path}"
+        return state
+
+    loader = PyPDFLoader(str(pdf_path))
+    try:
+        docs = loader.load()
+        state["chunks_raw"] = docs
+    except Exception as exc:
+        state["error"] = str(exc)
+    return state

--- a/project_root/nodes/retrieve_answer.py
+++ b/project_root/nodes/retrieve_answer.py
@@ -1,0 +1,46 @@
+from typing import Dict, Any
+
+from langchain.chains import RetrievalQA
+from langchain_community.chat_models import ChatOpenAI
+
+
+LLM = ChatOpenAI(model_name="gpt-3.5-turbo", temperature=0)
+
+
+def retrieve(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Retrieve relevant documents from vector store."""
+    vectordb = state.get("vector")
+    query = state.get("user_query")
+    if not vectordb or not query:
+        state["error"] = "Missing vector store or query"
+        return state
+
+    try:
+        docs = vectordb.similarity_search(query, k=4)
+        state["retrieved_docs"] = docs
+    except Exception as exc:
+        state["error"] = str(exc)
+    return state
+
+
+def answer(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Answer user question based on retrieved docs."""
+    docs = state.get("retrieved_docs")
+    query = state.get("user_query")
+    vectordb = state.get("vector")
+    lang_option = state.get("lang_option", "한국어")
+    if not docs or not query or not vectordb:
+        state["error"] = "No documents or query for answering"
+        return state
+
+    try:
+        qa_chain = RetrievalQA.from_chain_type(llm=LLM, retriever=vectordb.as_retriever())
+        answer_ko = qa_chain.run(query + "\n한국어로 답변해 주세요.")
+        state["answer_ko"] = answer_ko
+
+        if "영어" in lang_option:
+            answer_en = qa_chain.run(query + "\nPlease answer in English.")
+            state["answer_en"] = answer_en
+    except Exception as exc:
+        state["error"] = str(exc)
+    return state

--- a/project_root/nodes/split.py
+++ b/project_root/nodes/split.py
@@ -1,0 +1,19 @@
+from typing import Dict, Any
+
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+
+
+def split(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Split loaded documents into chunks under 1000 tokens."""
+    raw_docs = state.get("chunks_raw")
+    if not raw_docs:
+        state["error"] = "No documents to split"
+        return state
+
+    splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=100)
+    try:
+        chunks = splitter.split_documents(raw_docs)
+        state["chunks"] = chunks
+    except Exception as exc:
+        state["error"] = str(exc)
+    return state

--- a/project_root/nodes/summarize.py
+++ b/project_root/nodes/summarize.py
@@ -1,0 +1,46 @@
+from typing import Dict, Any
+
+from langchain.chains.summarize import load_summarize_chain
+from langchain_community.chat_models import ChatOpenAI
+
+
+LLM = ChatOpenAI(model_name="gpt-3.5-turbo", temperature=0)
+
+
+def summarize(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Generate summary in the requested style."""
+    docs = state.get("chunks")
+    if not docs:
+        state["error"] = "No documents to summarize"
+        return state
+
+    summary_type = state.get("summary_type", "tldr")
+    lang_option = state.get("lang_option", "한국어")
+    prompt_map_ko = {
+        "tldr": "한국어로 3줄 요약해 주세요 (250~300자).",
+        "section": "각 섹션별로 한 문장씩 한국어 bullet을 생성하세요.",
+        "deep": "한국어로 700~900자 심층 요약을 작성하세요.",
+    }
+    prompt_map_en = {
+        "tldr": "Provide a three-sentence TL;DR in English.",
+        "section": "Summarize each section in one English sentence bullet.",
+        "deep": "Write a detailed English summary in 5-7 sentences.",
+    }
+
+    chain = load_summarize_chain(LLM, chain_type="map_reduce")
+    try:
+        summary_ko = chain.run({
+            "input_documents": docs,
+            "question": prompt_map_ko.get(summary_type, prompt_map_ko["tldr"]),
+        })
+        state["summary_ko"] = summary_ko
+
+        if "영어" in lang_option:
+            summary_en = chain.run({
+                "input_documents": docs,
+                "question": prompt_map_en.get(summary_type, prompt_map_en["tldr"]),
+            })
+            state["summary_en"] = summary_en
+    except Exception as exc:
+        state["error"] = str(exc)
+    return state

--- a/project_root/nodes/web_search.py
+++ b/project_root/nodes/web_search.py
@@ -1,0 +1,27 @@
+from typing import Dict, Any, List
+
+from langchain_community.utilities.tavily_search import TavilySearchAPIWrapper
+
+
+_searcher = TavilySearchAPIWrapper()
+
+
+def web_search(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Perform web search for given keywords and store references."""
+    if not state.get("ext_flag"):
+        return state
+
+    keywords = state.get("keywords") or []
+    if not keywords:
+        return state
+
+    refs: List[dict] = []
+    try:
+        for kw in keywords[:3]:
+            results = _searcher.results(kw, 3)
+            for r in results:
+                refs.append({"title": r["title"], "url": r["url"]})
+        state["external_refs"] = refs
+    except Exception as exc:
+        state["error"] = str(exc)
+    return state


### PR DESCRIPTION
## Summary
- expand `PaperState` to include language and web search flags
- add multi-language summary and answer generation
- integrate ext flag and language options in Streamlit UI

## Testing
- `python -m py_compile project_root/nodes/*.py project_root/graph_build.py project_root/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68537407383883329bcb4bf36b7f8bce